### PR TITLE
docker: directly install ssb-server itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY --chown=node npm-shrinkwrap.json ./
 COPY package*.json ./
 RUN npm i --only=production
 COPY . .
+RUN npm install -g .
 
 EXPOSE 8008
 EXPOSE 8118


### PR DESCRIPTION
`ssb-server` was not getting installed into the image before. This commit makes it available in the container's PATH